### PR TITLE
Fix(oauth2): enforce owner-scoped PAT deletion

### DIFF
--- a/services/web/modules/oauth2-server/app/src/OAuthPersonalAccessTokenController.mjs
+++ b/services/web/modules/oauth2-server/app/src/OAuthPersonalAccessTokenController.mjs
@@ -61,7 +61,10 @@ const PersonalAccessTokenController = {
             return res.status(400).json({ message: 'Token id is required' })
         }
 
-        await OAuthPersonalAccessTokenManager.removeToken(tokenId)
+        const result = await OAuthPersonalAccessTokenManager.removeToken(tokenId, user._id)
+        if (!result || result.deletedCount !== 1) {
+            return res.status(404).json({ message: 'Token not found' })
+        }
 
         return res.json({ 
             message: 'Token deleted',

--- a/services/web/modules/oauth2-server/app/src/OAuthPersonalAccessTokenManager.mjs
+++ b/services/web/modules/oauth2-server/app/src/OAuthPersonalAccessTokenManager.mjs
@@ -87,10 +87,15 @@ const PersonalAccessTokenManager = {
         return accessToken
     },
 
-    // Delete a personal access token
-    async removeToken(tokenId) {
+    // Delete a personal access token owned by a specific user
+    async removeToken(tokenId, userId) {
+        if (!ObjectId.isValid(tokenId)) {
+            return { deletedCount: 0 }
+        }
         const query = {
             _id: new ObjectId(tokenId),
+            user_id: userId,
+            type: 'personal_access_token',
         }
 
         // Delete token from database


### PR DESCRIPTION
## Summary
This PR fixes an authorization gap in PAT deletion by enforcing token ownership at deletion time.

## Changes
- Updated `removeToken` to require both `tokenId` and `userId`.
- Scoped delete query to:
  - `_id = tokenId`
  - `user_id = userId`
  - `type = personal_access_token`
- Added invalid `tokenId` handling with `ObjectId.isValid(...)` to avoid deletion attempts on malformed IDs.
- Updated delete controller flow to:
  - pass `user._id` into `removeToken(...)`
  - return `404 Token not found` when no owned token is deleted (`deletedCount !== 1`)

## Security Impact
- Prevents users from deleting PATs they do not own via token ID alone.