### PR TITLE
CI: add release multi-arch workflow for git-bridge image

### DIFF
--- a/.github/workflows/build_release_image.yml
+++ b/.github/workflows/build_release_image.yml
@@ -185,3 +185,146 @@ jobs:
           org-name: ayaka-notes
           untagged-only: true
           token: ${{ secrets.ORGTOKEN }}
+
+  build_git_bridge:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - platform: linux/amd64
+          runner: ubuntu-latest
+        - platform: linux/arm64
+          runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Get latest release branch
+        run: |
+          echo "LATEST_RELEASE_REF=$(git ls-remote --heads --sort='version:refname' https://github.com/ayaka-notes/overleaf-pro.git 'release-v*' | tail -n1 | cut -d/ -f3)" >> $GITHUB_ENV
+      - name: "Checkout Repository"
+        uses: actions/checkout@main
+        with:
+          ref: ${{ env.LATEST_RELEASE_REF }}
+      - name: Resolve MONOREPO_REVISION
+        run: |
+          echo "MONOREPO_REVISION=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          arch=${platform##*/}
+          echo "PLATFORM_PAIR=$arch" >> $GITHUB_ENV
+      - name: Set release version outputs
+        id: set_version
+        run: |
+          ref="${{ env.LATEST_RELEASE_REF }}"
+          # ref is like release-v1.2.3, we want to extract 1.2.3
+          version="${ref#release-v}"
+          echo "version=$version" >> $GITHUB_ENV
+          echo "version=$version" >> $GITHUB_OUTPUT
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}/git-bridge
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{github.actor}}
+          password: ${{ secrets.ORGTOKEN }}
+
+      - name: Set up Docker (enable containerd image store)
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+      - name: Set up Buildx (docker driver)
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+
+      - name: Build Git Bridge Image
+        id: build_git_bridge
+        uses: docker/build-push-action@v6
+        with:
+          context: ./services/git-bridge
+          file: ./services/git-bridge/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            com.overleaf.pro.revision=${{ env.MONOREPO_REVISION }}
+          tags: ${{ env.REGISTRY_IMAGE }}/git-bridge:${{ env.version }}-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name-canonical=true,push=true
+          provenance: false
+          sbom: false
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build_git_bridge.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-bridge-digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+    outputs:
+      version: ${{ steps.set_version.outputs.version }}
+
+  merge_git_bridge:
+    runs-on: ubuntu-latest
+    needs:
+      - build_git_bridge
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: git-bridge-digests-*
+          merge-multiple: true
+
+      - name: Login to GHCR Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{github.actor}}
+          password: ${{ secrets.ORGTOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}/git-bridge
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ needs.build_git_bridge.outputs.version }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}/git-bridge@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}/git-bridge:${{ needs.build_git_bridge.outputs.version }}
+
+      - name: Delete old images
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: overleaf-pro/git-bridge
+          cut-off: 1s, UTC+8
+          account-type: org
+          org-name: ayaka-notes
+          untagged-only: true
+          token: ${{ secrets.ORGTOKEN }}


### PR DESCRIPTION
### Motivation
- Automate building and publishing multi-arch release images for the `git-bridge` service so release pipelines produce both `linux/amd64` and `linux/arm64` artifacts.
- Reuse the existing release workflow pattern (per-arch build -> upload digest -> create manifest) to keep behavior consistent with other images.

### Description
- Added two jobs to `.github/workflows/build_release_image.yml`: `build_git_bridge` to build and upload per-architecture images from `services/git-bridge/Dockerfile` and `merge_git_bridge` to create and push a multi-arch manifest for `ghcr.io/.../git-bridge` with `latest` and release-version tags.
- `build_git_bridge` runs for `linux/amd64` and `linux/arm64`, extracts the latest `release-v*` ref, sets `version`, runs `docker/build-push-action@v6` with `context: ./services/git-bridge`, and uploads digest artifacts per-arch.
- `merge_git_bridge` downloads the per-arch digest artifacts and uses `docker buildx imagetools create` to assemble and push the manifest, then runs an `imagetools inspect` and retention cleanup for `overleaf-pro/git-bridge`.
- The `services/git-bridge/Dockerfile` was inspected and left unchanged, and the workflow reuses metadata labels and registry login consistent with the existing release jobs.

### Testing
- Parsed the updated workflow YAML with Ruby using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build_release_image.yml'); puts 'ok'"`, which returned `ok` indicating valid YAML.
- Attempted to validate with Python YAML but the environment lacked `PyYAML` causing the `ModuleNotFoundError`, which is an environment issue and not a workflow error.
- Committed the changes and recorded the change with a local commit (`ci: add multi-arch release workflow for git-bridge image`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3793a8d28832385d174a9fe9ea809)