### PR TITLE
Fix container restart loop when sandboxed compiles  var is null

### DIFF
--- a/server-ce/config/env.sh
+++ b/server-ce/config/env.sh
@@ -17,6 +17,6 @@ export WEB_API_HOST=127.0.0.1
 # we need to set the TEXLIVE_IMAGE_USER to www-data so that the
 # sandboxed compiles container can access the files 
 # created by the web container.
-if [ "$SANDBOXED_COMPILES_SIBLING_CONTAINERS" = "true" ]; then
+if [ "${SANDBOXED_COMPILES_SIBLING_CONTAINERS:-}" = "true" ]; then
   export TEXLIVE_IMAGE_USER=www-data
 fi


### PR DESCRIPTION

## Description
<!-- Goal of the pull request -->
Use ${VAR:-} default value syntax for SANDBOXED_COMPILES_SIBLING_CONTAINERS in env.sh to prevent "unbound variable" error under set -u when the variable is not defined (i.e. when sandboxed compiles is turned off).


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
Fix container restart loop when sandboxed compiles  var is null

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
